### PR TITLE
Add service networking connection

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: no-commit-to-branch
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.83.5
+    rev: v1.83.6
     hooks:
       - id: terraform_fmt
 

--- a/global/infra/README.md
+++ b/global/infra/README.md
@@ -23,10 +23,10 @@ No requirements.
 
 | Name | Type |
 |------|------|
-| [google_compute_global_address.service_network_peering](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_address) | resource |
+| [google_compute_global_address.service_network_peering_range](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_address) | resource |
 | [google_compute_shared_vpc_service_project.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_shared_vpc_service_project) | resource |
 | [google_project_iam_member.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_service_networking_connection.standard_shared](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_networking_connection) | resource |
+| [google_service_networking_connection.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_networking_connection) | resource |
 
 ## Inputs
 

--- a/global/infra/README.md
+++ b/global/infra/README.md
@@ -9,7 +9,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 5.5.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 5.6.0 |
 
 ## Modules
 
@@ -23,8 +23,10 @@ No requirements.
 
 | Name | Type |
 |------|------|
+| [google_compute_global_address.service_network_peering](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_address) | resource |
 | [google_compute_shared_vpc_service_project.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_shared_vpc_service_project) | resource |
 | [google_project_iam_member.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_service_networking_connection.standard_shared](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_networking_connection) | resource |
 
 ## Inputs
 

--- a/global/infra/main.tf
+++ b/global/infra/main.tf
@@ -76,6 +76,7 @@ module "host_project" {
     "iam.googleapis.com",
     "monitoring.googleapis.com",
     "pubsub.googleapis.com",
+    "servicenetworking.googleapis.com",
     "serviceusage.googleapis.com"
   ]
 }

--- a/global/infra/main.tf
+++ b/global/infra/main.tf
@@ -110,6 +110,7 @@ module "service_project" {
     "iam.googleapis.com",
     "monitoring.googleapis.com",
     "pubsub.googleapis.com",
+    "servicenetworking.googleapis.com",
     "serviceusage.googleapis.com"
   ]
 }
@@ -123,6 +124,19 @@ module "vpc" {
   name       = "kitchen-vpc"
   project    = module.host_project.project_id
   shared_vpc = true
+}
+
+# Compute Global Address Resource
+# https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_address
+
+resource "google_compute_global_address" "service_network_peering" {
+  address       = "172.16.0.0"
+  address_type  = "INTERNAL"
+  name          = "service-network-peering-range"
+  network       = module.vpc.self_link
+  prefix_length = 16
+  project       = module.host_project.project_id
+  purpose       = "VPC_PEERING"
 }
 
 # Compute Shared VPC Service Project Resource
@@ -141,4 +155,13 @@ resource "google_project_iam_member" "this" {
   member  = "serviceAccount:service-${module.service_project.project_number}@container-engine-robot.iam.gserviceaccount.com"
   project = module.host_project.project_id
   role    = each.key
+}
+
+# Service Networking Connection Resource
+# https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_networking_connection
+
+resource "google_service_networking_connection" "standard_shared" {
+  network                 = module.vpc.self_link
+  reserved_peering_ranges = [google_compute_global_address.service_network_peering.name]
+  service                 = "servicenetworking.googleapis.com"
 }

--- a/global/infra/main.tf
+++ b/global/infra/main.tf
@@ -129,7 +129,7 @@ module "vpc" {
 # Compute Global Address Resource
 # https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_address
 
-resource "google_compute_global_address" "service_network_peering" {
+resource "google_compute_global_address" "service_network_peering_range" {
   address       = "172.16.0.0"
   address_type  = "INTERNAL"
   name          = "service-network-peering-range"
@@ -160,8 +160,8 @@ resource "google_project_iam_member" "this" {
 # Service Networking Connection Resource
 # https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_networking_connection
 
-resource "google_service_networking_connection" "standard_shared" {
+resource "google_service_networking_connection" "this" {
   network                 = module.vpc.self_link
-  reserved_peering_ranges = [google_compute_global_address.service_network_peering.name]
+  reserved_peering_ranges = [google_compute_global_address.service_network_peering_range.name]
   service                 = "servicenetworking.googleapis.com"
 }


### PR DESCRIPTION
This pull request adds a service networking connection to the project. The service networking connection resource is used to establish a peering connection between the project's VPC network and the Google service network. This allows the project to access Google services.
